### PR TITLE
scross icon on tags now deletes tag, not click of tag

### DIFF
--- a/front-end/src/assets/styles/document-edit.scss
+++ b/front-end/src/assets/styles/document-edit.scss
@@ -256,6 +256,17 @@
                 &::before {
                     content: '#';
                 }
+
+                .delete-container {
+                    margin-left: 5px;
+                    .delete {
+                        margin: 2px 0;
+                        width: 15px;
+                        height: 15px;
+                        max-height: 15px;
+                        min-height: 15px;
+                    }
+                }
             }
 
             button:hover {

--- a/front-end/src/views/Edit.vue
+++ b/front-end/src/views/Edit.vue
@@ -76,10 +76,13 @@
         <div v-if="tags.length">
           <button v-for="tag in tags"
                   :key="tag"
-                  @click.stop="deleteTag(tag)"
+                  @click.stop="triggerDropdown('tags')"
                   :style="getBackgroundColor(tag)"
           >
-            {{tag}} <span><uil-times></uil-times></span>
+            {{tag}}
+            <span @click.stop="deleteTag(tag)" class="delete-container">
+              <uil-times class="delete"></uil-times>
+            </span>
           </button>
         </div>
         <div v-else>


### PR DESCRIPTION
fixed the flow of how a tag is removed in edit. Tag now only deletes when cross icon is clicked

updated files:
Edit.vue - add click handler to remove tag on cross icon, not the whole tag.
document-edit.scss - added styling to the cross icon to make it more obviously clickable